### PR TITLE
Handle empty extract_frame_from_mp4 result without crashing

### DIFF
--- a/screentap-app/src-tauri/src/db.rs
+++ b/screentap-app/src-tauri/src/db.rs
@@ -305,13 +305,22 @@ pub fn get_screenshot_as_base64_string(file_path: &str, mp4_file_path: &str, mp4
 }
 
 fn get_screenshot_base64_from_mp4(mp4_file_path: &str, mp4_frame_id: i32) -> String {
-    
-    let frame_data = screen_ocr_swift_rs::extract_frame_from_mp4(
+
+    let frame_data_option = screen_ocr_swift_rs::extract_frame_from_mp4(
         mp4_file_path, 
         mp4_frame_id as isize
-    ).unwrap();
-    
-    BASE64.encode(frame_data)
+    );
+
+    match frame_data_option {
+        Some(frame_data) => {
+            BASE64.encode(frame_data)
+        },
+        None => {
+            let bt = Backtrace::new();
+            println!("Error: get_screenshot_base64_from_mp4() called with non-existent frame.  Returning empty data for frame.  Stack trace:\n{:?}", bt);
+            String::from("")
+        }
+    }
 
 }
 


### PR DESCRIPTION
Fixes https://github.com/tleyden/screentap/issues/43