### PR TITLE
Don't do inference if alerts are auto-snoozed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ test-image-gallery
 local_test_dataset
 screentap-app/plugins/focusguard/*.llamafile
 screentap-app/plugins/focusguard/config.toml
+
+# Ignore all emacs backup files
+*~

--- a/screentap-app/plugins/focusguard/config_sample.toml
+++ b/screentap-app/plugins/focusguard/config_sample.toml
@@ -33,7 +33,7 @@ productivity_score_threshold = 6
 # When resizing images, resize the longest size to this pixel value.
 # Set this to a lower value to reduce the OpenAI token costs, at the
 # expense of results quality.
-image_dimension_longest_side = 1200
+image_dimension_longest_side = 1600
 
 # Ignore this param, just internal stuff
 dev_mode = false

--- a/screentap-app/plugins/focusguard/config_sample.toml
+++ b/screentap-app/plugins/focusguard/config_sample.toml
@@ -7,9 +7,10 @@ job_title = "Software Engineer at Acme, Inc"
 job_role = "Software engineer with the tech stack: VS Code, iterm terminal, AWS console, GCP cloud console, and many other tools and technologies related to coding.  Pretty much any time I am writing code or looking at a terminal it is work related.  As a software engineer I have a broad role in technology and AI, and often have to read online content or watch technical youtube videos that are related to software engineering.  Also I have to use Slack a lot to communicate with my Acme inc teammates.  Some common distractions are: using iMessage and WhatsApp and non-Arcee Slack workspace to chat with friends about non work related stuff, checking the news and stocks.  Some websites like Reddit can be either work related or not work related, depending on the actual content.  Likewise, chatting with friends on iMessage or WhatsApp can sometimes be work related, or sometimes not be work related, depending on the context of the conversation"
 
 # The duration (in seconds) between distraction alerts.
-# Set this to a smaller number if you would like more 
-# frequent alerts
-duration_between_alerts_secs = 300 # 5 minutes
+# The smaller the number, the more often you will get distraction alerts. 
+# Keep in mind that reducing this number could increase costs of OpenAI 
+# usage, because it will need to analyze screenshots more frequently.
+duration_between_alerts_secs = 900 # 15 minutes
 
 # Choose the llava vision model backend.  Valid values are:
 # - "LlamaFileSubprocess"


### PR DESCRIPTION
When a distraction alert is shown, it will auto-snooze alerts for a configurable amount of time.  During that auto-snooze, there is no point to hit the vision model .. so it short-circuits this behavior.

Also default the snooze window to 15 mins and add a warning in the config comments that reducing the value will increase openai costs

If it's not auto-snoozed, it will still make a lot of calls to the vision model, so the costs could still be prohibitively high.  Still WIP.