### PR TITLE
FocusGuard: Record user feedback when distraction alerts are shown

### DIFF
--- a/screentap-app/plugins/focusguard/.gitignore
+++ b/screentap-app/plugins/focusguard/.gitignore
@@ -1,0 +1,1 @@
+distraction_alert_screenshots/

--- a/screentap-app/src-tauri/src/main.rs
+++ b/screentap-app/src-tauri/src/main.rs
@@ -27,7 +27,7 @@ static DATABASE_FILENAME: &str = "screentap.db";
 /**
  * Capture screenshots on a fixed schedule 
  */
-static DURATION_BETWEEN_SCREEN_CAPTURES_CHECKS: i64 = 5;
+static DURATION_BETWEEN_SCREEN_CAPTURES_CHECKS: i64 = 30;
 
 
 #[tauri::command]

--- a/screentap-app/src-tauri/src/main.rs
+++ b/screentap-app/src-tauri/src/main.rs
@@ -120,7 +120,9 @@ fn get_effective_app_dir(app_handle: tauri::AppHandle) -> PathBuf {
 }
 
 fn setup_handler2(app: &mut tauri::App, focusguard: focusguard::FocusGuard) -> Result<(), Box<dyn std::error::Error + 'static>> {
-    println!("setup_handler2 called with focusguard");
+    let my_state: tauri::State<HashMap<&str, &str>> = app.state();
+
+    println!("setup_handler2 called with focusguard.  my_state: {:?}", my_state);
     setup_handler(app)
 }   
 
@@ -333,12 +335,13 @@ fn main() {
         .add_item(quit);
 
     tauri::Builder::default()
+    .manage(state)
     .setup(|app| {
         setup_handler2(app, focus_guard)
     })
     .system_tray(SystemTray::new().with_menu(system_tray_menu))
     .on_system_tray_event(handle_system_tray_event)
-    .manage(state)
+    
     .invoke_handler(tauri::generate_handler![
         search_screenshots, 
         browse_screenshots]

--- a/screentap-app/src-tauri/src/main.rs
+++ b/screentap-app/src-tauri/src/main.rs
@@ -58,9 +58,9 @@ fn search_screenshots(app_handle: tauri::AppHandle, term: &str) -> Vec<HashMap<S
 }
 
 #[tauri::command]
-fn browse_screenshots(state: tauri::State<HashMap<&str, &str>>, app_handle: tauri::AppHandle, cur_id: i32, direction: &str) -> Vec<HashMap<String, String>> {
+fn browse_screenshots(state: tauri::State<focusguard::FocusGuard>, app_handle: tauri::AppHandle, cur_id: i32, direction: &str) -> Vec<HashMap<String, String>> {
 
-    println!("browse_screenshots: cur_id: {}, direction: {} state: {:?}", cur_id, direction, state);
+    println!("browse_screenshots: cur_id: {}, direction: {} state: {:?}", cur_id, direction, state.job_role);
 
 
     let app_data_dir: PathBuf = get_effective_app_dir(app_handle);
@@ -119,10 +119,10 @@ fn get_effective_app_dir(app_handle: tauri::AppHandle) -> PathBuf {
     app_data_dir
 }
 
-fn setup_handler2(app: &mut tauri::App, focusguard: focusguard::FocusGuard) -> Result<(), Box<dyn std::error::Error + 'static>> {
-    let my_state: tauri::State<HashMap<&str, &str>> = app.state();
+fn setup_handler2(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let my_state: tauri::State<focusguard::FocusGuard> = app.state();
 
-    println!("setup_handler2 called with focusguard.  my_state: {:?}", my_state);
+    println!("setup_handler2 called with focusguard.  job_role: {:?}", my_state.job_role);
     setup_handler(app)
 }   
 
@@ -335,9 +335,9 @@ fn main() {
         .add_item(quit);
 
     tauri::Builder::default()
-    .manage(state)
+    .manage(focus_guard)
     .setup(|app| {
-        setup_handler2(app, focus_guard)
+        setup_handler2(app)
     })
     .system_tray(SystemTray::new().with_menu(system_tray_menu))
     .on_system_tray_event(handle_system_tray_event)

--- a/screentap-app/src-tauri/src/main.rs
+++ b/screentap-app/src-tauri/src/main.rs
@@ -157,14 +157,23 @@ fn setup_handler(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error +
     );
 
     // Create a focusguard instance
+    let screentap_db_filename_fq_path = app_data_dir.join(db_filename_path);
     let mut focus_guard_option = focusguard::FocusGuard::new_from_config(
         // Clone app_data_dir so focusguard can own the app data dir path instance
         // and we avoid reference lifetime issues
         // TODO: review this, it feels a bit overcomplicated
-        app_data_dir.clone(),  
+        app_data_dir.clone(),
+        screentap_db_filename_fq_path,
     );
+
     if focus_guard_option.is_none() {
         println!("FocusGuard not initialized");
+    } else {
+        // Put a copy of the focusguard instance into the app managed state,
+        // so we can at least access the configuration from handlers.
+        // Why a clone?  If the original focusguard is moved into the managed
+        // state, then the closure below passed to the thread will no longer work        
+        app.manage(focus_guard_option.clone());
     }
 
     // Get an app handle from the app since this can be moved to threads

--- a/screentap-app/src-tauri/src/main.rs
+++ b/screentap-app/src-tauri/src/main.rs
@@ -58,9 +58,9 @@ fn search_screenshots(app_handle: tauri::AppHandle, term: &str) -> Vec<HashMap<S
 }
 
 #[tauri::command]
-fn browse_screenshots(app_handle: tauri::AppHandle, cur_id: i32, direction: &str) -> Vec<HashMap<String, String>> {
+fn browse_screenshots(state: tauri::State<HashMap<&str, &str>>, app_handle: tauri::AppHandle, cur_id: i32, direction: &str) -> Vec<HashMap<String, String>> {
 
-    println!("browse_screenshots: cur_id: {}, direction: {}", cur_id, direction);
+    println!("browse_screenshots: cur_id: {}, direction: {} state: {:?}", cur_id, direction, state);
 
 
     let app_data_dir: PathBuf = get_effective_app_dir(app_handle);
@@ -119,6 +119,11 @@ fn get_effective_app_dir(app_handle: tauri::AppHandle) -> PathBuf {
     app_data_dir
 }
 
+fn setup_handler2(app: &mut tauri::App, focusguard: focusguard::FocusGuard) -> Result<(), Box<dyn std::error::Error + 'static>> {
+    println!("setup_handler2 called with focusguard");
+    setup_handler(app)
+}   
+
 fn setup_handler(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error + 'static>> {
 
     let app_handle = app.handle();
@@ -166,7 +171,7 @@ fn setup_handler(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error +
     );
     if focus_guard_option.is_none() {
         println!("FocusGuard not initialized");
-    }
+    } 
 
     // Get an app handle from the app since this can be moved to threads
     let app_handle = app.app_handle();
@@ -310,6 +315,13 @@ fn main() {
 
     println!("Starting screentap...");
 
+    let mut state = HashMap::new();
+    state.insert("k", "v");
+
+    let fake_path_buf = PathBuf::from("/Users/tleyden/Library/Application Support/com.screentap-app.dev");
+    let focus_guard_option = focusguard::FocusGuard::new_from_config(fake_path_buf);
+    let focus_guard = focus_guard_option.unwrap();
+
     let quit = CustomMenuItem::new("quit".to_string(), "Quit").accelerator("Cmd+Q");
     let show_hide_window = CustomMenuItem::new("search".to_string(), "Search");
     let browse_screenshots_menu_item = CustomMenuItem::new("browse_screenshots".to_string(), "Browse");
@@ -321,9 +333,12 @@ fn main() {
         .add_item(quit);
 
     tauri::Builder::default()
-    .setup(setup_handler)
+    .setup(|app| {
+        setup_handler2(app, focus_guard)
+    })
     .system_tray(SystemTray::new().with_menu(system_tray_menu))
     .on_system_tray_event(handle_system_tray_event)
+    .manage(state)
     .invoke_handler(tauri::generate_handler![
         search_screenshots, 
         browse_screenshots]

--- a/screentap-app/src-tauri/src/plugins/focusguard/config.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/config.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::path::PathBuf;
 use toml;
 use std::fs;
 use serde::Deserialize;
@@ -17,12 +18,22 @@ pub struct FocusGuardConfig {
 
 impl FocusGuardConfig {
 
-    pub fn new(app_data_dir: &Path) -> Option<FocusGuardConfig> {
-
-        // Build path to config.toml in expected place
-        let toml_config = app_data_dir
+    pub fn get_focusguard_root_dir(app_data_dir: &PathBuf) -> PathBuf {
+        app_data_dir
             .join("plugins")
             .join("focusguard")
+    }
+
+    pub fn new(app_data_dir: &Path) -> Option<FocusGuardConfig> {
+
+        let focusguard_root_dir = FocusGuardConfig::get_focusguard_root_dir(&app_data_dir.to_path_buf());
+
+        // Build path to config.toml in expected place
+        // let toml_config = app_data_dir
+        //     .join("plugins")
+        //     .join("focusguard")
+        //     .join("config.toml");
+        let toml_config = focusguard_root_dir
             .join("config.toml");
 
         // If config.toml not found, return None

--- a/screentap-app/src-tauri/src/plugins/focusguard/config.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/config.rs
@@ -29,10 +29,6 @@ impl FocusGuardConfig {
         let focusguard_root_dir = FocusGuardConfig::get_focusguard_root_dir(&app_data_dir.to_path_buf());
 
         // Build path to config.toml in expected place
-        // let toml_config = app_data_dir
-        //     .join("plugins")
-        //     .join("focusguard")
-        //     .join("config.toml");
         let toml_config = focusguard_root_dir
             .join("config.toml");
 

--- a/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
@@ -3,23 +3,65 @@ use rusqlite::params;
 use chrono::Local;
 use crate::plugins::focusguard::FocusGuard;
 use crate::plugins::focusguard::config::FocusGuardConfig;
+use std::path::PathBuf;
+
 
 #[tauri::command]
 pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, screenshot_id: i64, png_image_path: &str, job_title: &str, job_role: &str) -> () {
 
-    println!("Distraction alert rating received: liked: {}, screenshot_id: {} png_image_path: {} job_title: {} job_role: {}", 
-        liked, screenshot_id, png_image_path, job_title, job_role);
+    println!("Distraction alert rating received: liked: {}, screenshot_id: {} png_image_path: {}", 
+        liked, screenshot_id, png_image_path);
 
     let focus_guard_clone: tauri::State<Option<FocusGuard>> = app_handle.state();
-
     let focus_guard_ref = focus_guard_clone.as_ref().unwrap();
 
-    println!("focus_guard_clone.screentap_db_path: {:?}", focus_guard_ref.screentap_db_path);
+    let app_data_dir = &focus_guard_ref.app_data_dir;
 
-    let conn = crate::plugins::focusguard::FocusGuard::get_db_conn(&focus_guard_ref.screentap_db_path);
+    let target_image_path = copy_image_to_distraction_alerts_screenshots_dir(
+        app_data_dir, 
+        png_image_path, 
+        screenshot_id
+    );
 
+    let screentab_db_path = &focus_guard_ref.screentap_db_path;
+
+    let user_rating = if liked { 1 } else { 0 };
+
+    insert_distraction_alert_record(
+        screentab_db_path, 
+        screenshot_id, 
+        user_rating, 
+        target_image_path.to_str().unwrap(), 
+        job_title, 
+        job_role
+    );
+
+
+
+}
+
+
+fn insert_distraction_alert_record(screentap_db_path: &PathBuf, screenshot_id: i64, user_rating: i32, file_path: &str, job_title: &str, job_role: &str) -> () {
+
+    let conn = crate::plugins::focusguard::FocusGuard::get_db_conn(screentap_db_path);
+
+    let now = Local::now().naive_utc();
+
+    let result = conn.execute(
+        "INSERT INTO focusguard_distraction_alerts (timestamp, screenshot_id, user_rating, file_path, job_title, job_role) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![now.timestamp(), screenshot_id, user_rating, file_path, job_title, job_role],
+    );
+    match result {
+        Ok(_) => println!("Inserted new record into focusguard_distraction_alerts"),
+        Err(e) => println!("Error inserting new record into focusguard_distraction_alerts: {:?}", e),
+    }
+
+}
+
+fn copy_image_to_distraction_alerts_screenshots_dir(app_data_dir: &PathBuf, png_image_path: &str, screenshot_id: i64) -> std::path::PathBuf {
+ 
     // Copy the image file to a specific location so it doesn't get compacted into an mp4
-    let focusguard_root_dir = FocusGuardConfig::get_focusguard_root_dir(&focus_guard_ref.app_data_dir);
+    let focusguard_root_dir = FocusGuardConfig::get_focusguard_root_dir(app_data_dir);
 
     // Is there a distraction alert screenshots dir?  If not, create it
     let distraction_alerts_screenshots_dir = focusguard_root_dir.join("distraction_alert_screenshots");
@@ -34,33 +76,6 @@ pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, scree
     // Copy the image to the distraction_alert_screenshots dir
     let target_image_path = distraction_alerts_screenshots_dir.join(format!("{}_{}.png", screenshot_id, png_image_filename.to_str().unwrap()));
     std::fs::copy(png_image_path, &target_image_path).expect("Failed to copy image to distraction_alerts_screenshots_dir");
-    
-    println!("focusguard_root_dir: {:?}", focusguard_root_dir);
 
-    // Insert a new record into the DB, using the dataset dir 
-
-    let user_rating = if liked { 1 } else { 0 };
-
-    let now = Local::now().naive_utc();
-
-    let result = conn.execute(
-        "INSERT INTO focusguard_distraction_alerts (timestamp, screenshot_id, user_rating, file_path, job_title, job_role) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        params![now.timestamp(), screenshot_id, user_rating, target_image_path.to_str(), job_title, job_role],
-    );
-    match result {
-        Ok(_) => println!("Inserted new record into focusguard_distraction_alerts"),
-        Err(e) => println!("Error inserting new record into focusguard_distraction_alerts: {:?}", e),
-    }
-
-    // Figure out the path to the DB by calling a static method
-
-    // Open the DB connection
-
-    // Write a new record to the DB
-
-    // Get the job role and description used for inference on the LLM, to help measure prompt engineering
-    
-
-
-
+    target_image_path
 }

--- a/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
@@ -1,9 +1,10 @@
 
 #[tauri::command]
 // pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, productivity_score: i32, raw_llm_result: &str, screenshot_id: i64) -> () {
-pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, screenshot_id: i64, png_image_path: &str) -> () {
+pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, screenshot_id: i64, png_image_path: &str, job_title: &str, job_role: &str) -> () {
 
-    println!("Distraction alert rating received: liked: {}, screenshot_id: {} png_image_path: {}", liked, screenshot_id, png_image_path);
+    println!("Distraction alert rating received: liked: {}, screenshot_id: {} png_image_path: {} job_title: {} job_role: {}", 
+        liked, screenshot_id, png_image_path, job_title, job_role);
 
     // Figure out the path to the DB by calling a static method
 

--- a/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
@@ -1,10 +1,9 @@
 
-
 #[tauri::command]
 // pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, productivity_score: i32, raw_llm_result: &str, screenshot_id: i64) -> () {
-pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, screenshot_id: i64) -> () {
+pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, screenshot_id: i64, png_image_path: &str) -> () {
 
-    println!("Distraction alert rating received: liked: {}, screenshot_id: {}", liked, screenshot_id);
+    println!("Distraction alert rating received: liked: {}, screenshot_id: {} png_image_path: {}", liked, screenshot_id, png_image_path);
 
     // Figure out the path to the DB by calling a static method
 

--- a/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
@@ -1,8 +1,8 @@
 use tauri::Manager;
-
+use rusqlite::params;
+use chrono::Local;
 
 #[tauri::command]
-// pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, productivity_score: i32, raw_llm_result: &str, screenshot_id: i64) -> () {
 pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, screenshot_id: i64, png_image_path: &str, job_title: &str, job_role: &str) -> () {
 
     println!("Distraction alert rating received: liked: {}, screenshot_id: {} png_image_path: {} job_title: {} job_role: {}", 
@@ -10,15 +10,34 @@ pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, scree
 
     let focus_guard_clone: tauri::State<Option<crate::plugins::focusguard::FocusGuard>> = app_handle.state();
 
-    println!("focus_guard_clone.screentap_db_path: {:?}", focus_guard_clone.as_ref().unwrap().screentap_db_path);
+    let focus_guard_ref = focus_guard_clone.as_ref().unwrap();
+
+    println!("focus_guard_clone.screentap_db_path: {:?}", focus_guard_ref.screentap_db_path);
+
+    let conn = crate::plugins::focusguard::FocusGuard::get_db_conn(&focus_guard_ref.screentap_db_path);
+
+    // Copy the image file to a specific location so it doesn't get compacted into an mp4
+
+    // Insert a new record into the DB, using the dataset dir 
+
+    let user_rating = if liked { 1 } else { 0 };
+
+    let now = Local::now().naive_utc();
+
+    let result = conn.execute(
+        "INSERT INTO focusguard_distraction_alerts (timestamp, screenshot_id, user_rating, file_path, job_title, job_role) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![now.timestamp(), screenshot_id, user_rating, png_image_path, job_title, job_role],
+    );
+    match result {
+        Ok(_) => println!("Inserted new record into focusguard_distraction_alerts"),
+        Err(e) => println!("Error inserting new record into focusguard_distraction_alerts: {:?}", e),
+    }
 
     // Figure out the path to the DB by calling a static method
 
     // Open the DB connection
 
     // Write a new record to the DB
-
-    // Copy the image file to a specific location
 
     // Get the job role and description used for inference on the LLM, to help measure prompt engineering
     

--- a/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
@@ -1,6 +1,8 @@
 use tauri::Manager;
 use rusqlite::params;
 use chrono::Local;
+use crate::plugins::focusguard::FocusGuard;
+use crate::plugins::focusguard::config::FocusGuardConfig;
 
 #[tauri::command]
 pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, screenshot_id: i64, png_image_path: &str, job_title: &str, job_role: &str) -> () {
@@ -8,7 +10,7 @@ pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, scree
     println!("Distraction alert rating received: liked: {}, screenshot_id: {} png_image_path: {} job_title: {} job_role: {}", 
         liked, screenshot_id, png_image_path, job_title, job_role);
 
-    let focus_guard_clone: tauri::State<Option<crate::plugins::focusguard::FocusGuard>> = app_handle.state();
+    let focus_guard_clone: tauri::State<Option<FocusGuard>> = app_handle.state();
 
     let focus_guard_ref = focus_guard_clone.as_ref().unwrap();
 
@@ -17,6 +19,9 @@ pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, scree
     let conn = crate::plugins::focusguard::FocusGuard::get_db_conn(&focus_guard_ref.screentap_db_path);
 
     // Copy the image file to a specific location so it doesn't get compacted into an mp4
+    let focusguard_root_dir = FocusGuardConfig::get_focusguard_root_dir(&focus_guard_ref.app_data_dir);
+
+    println!("focusguard_root_dir: {:?}", focusguard_root_dir);
 
     // Insert a new record into the DB, using the dataset dir 
 

--- a/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
@@ -13,6 +13,9 @@ pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, scree
 
     // Copy the image file to a specific location
 
+    // Get the job role and description used for inference on the LLM, to help measure prompt engineering
+    
+
 
 
 }

--- a/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
@@ -1,0 +1,19 @@
+
+
+#[tauri::command]
+// pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, productivity_score: i32, raw_llm_result: &str, screenshot_id: i64) -> () {
+pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, screenshot_id: i64) -> () {
+
+    println!("Distraction alert rating received: liked: {}, screenshot_id: {}", liked, screenshot_id);
+
+    // Figure out the path to the DB by calling a static method
+
+    // Open the DB connection
+
+    // Write a new record to the DB
+
+    // Copy the image file to a specific location
+
+
+
+}

--- a/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/handlers.rs
@@ -1,3 +1,5 @@
+use tauri::Manager;
+
 
 #[tauri::command]
 // pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, productivity_score: i32, raw_llm_result: &str, screenshot_id: i64) -> () {
@@ -5,6 +7,10 @@ pub fn distraction_alert_rating(app_handle: tauri::AppHandle, liked: bool, scree
 
     println!("Distraction alert rating received: liked: {}, screenshot_id: {} png_image_path: {} job_title: {} job_role: {}", 
         liked, screenshot_id, png_image_path, job_title, job_role);
+
+    let focus_guard_clone: tauri::State<Option<crate::plugins::focusguard::FocusGuard>> = app_handle.state();
+
+    println!("focus_guard_clone.screentap_db_path: {:?}", focus_guard_clone.as_ref().unwrap().screentap_db_path);
 
     // Figure out the path to the DB by calling a static method
 

--- a/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
@@ -367,7 +367,7 @@ impl FocusGuard {
 
 
 
-    fn show_productivity_alert(&self, app: &tauri::AppHandle, productivity_score: i32, raw_llm_result: &str, _png_image_path: &Path, screenshot_id: i64) {
+    fn show_productivity_alert(&self, app: &tauri::AppHandle, productivity_score: i32, raw_llm_result: &str, png_image_path: &Path, screenshot_id: i64) {
 
         println!("Showing productivity alert for score: {}", productivity_score);
 
@@ -388,6 +388,7 @@ impl FocusGuard {
                     "screenshot_id": screenshot_id,
                     "productivity_score": productivity_score,
                     "raw_llm_result_base64": raw_llm_result_base64,
+                    "png_image_path": png_image_path.to_str().unwrap(),
                 });
 
                 // Emitting the event to the JavaScript running in the window
@@ -402,7 +403,7 @@ impl FocusGuard {
                 // Use an init script approach when creating a new window, since sending an event
                 // did not work in my testing.  Maybe it's not ready for events yet as some sort
                 // of race condition?
-                let init_script = get_init_script(screenshot_id, productivity_score, raw_llm_result);
+                let init_script = get_init_script(screenshot_id, productivity_score, raw_llm_result, png_image_path.to_str().unwrap());
 
                 // Create and show new window
                 let _w = tauri::WindowBuilder::new(
@@ -736,15 +737,16 @@ impl FocusGuard {
 }
 
 
-fn get_init_script(screenshot_id: i64, productivity_score: i32, raw_llm_result: &str) -> String {
+fn get_init_script(screenshot_id: i64, productivity_score: i32, raw_llm_result: &str, png_image_path: &str) -> String {
 
     let raw_llm_result_base64: String = BASE64.encode(raw_llm_result);
     
+    let png_image_path_base_64: String = BASE64.encode(png_image_path);
 
     format!(r#"    
-        window.__SCREENTAP_SCREENSHOT__ = {{ id: '{}', productivity_score: {}, raw_llm_result_base64: '{}' }};
+        window.__SCREENTAP_SCREENSHOT__ = {{ id: '{}', productivity_score: {}, raw_llm_result_base64: '{}', png_image_path_base_64: '{}' }};
 
-    "#, screenshot_id, productivity_score, raw_llm_result_base64)
+    "#, screenshot_id, productivity_score, raw_llm_result_base64, png_image_path_base_64)
 }
 
 // Structs for payload

--- a/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
@@ -23,6 +23,7 @@ use ollama_rs::{
 use tokio::runtime;
 
 mod utils;
+pub mod handlers;
 
 pub mod config;
 

--- a/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
@@ -389,6 +389,8 @@ impl FocusGuard {
                     "productivity_score": productivity_score,
                     "raw_llm_result_base64": raw_llm_result_base64,
                     "png_image_path": png_image_path.to_str().unwrap(),
+                    "job_title": self.job_title,
+                    
                 });
 
                 // Emitting the event to the JavaScript running in the window

--- a/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
@@ -128,6 +128,10 @@ pub struct FocusGuard {
 
 impl FocusGuard {
 
+    pub fn tauri_handler(&mut self, app: &tauri::AppHandle, event: String, payload: String) {
+        println!("FocusGuard received event: {} with payload: {}", event, payload);
+    }
+
     pub fn new_from_config(app_data_dir: PathBuf) -> Option<FocusGuard> {
 
         // Register plugin - create a new focusguard struct

--- a/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
@@ -21,6 +21,8 @@ use ollama_rs::{
     Ollama,
 };
 use tokio::runtime;
+use rusqlite::Result;
+
 
 mod utils;
 pub mod handlers;
@@ -31,6 +33,7 @@ pub mod config;
 // Create an enum with three possible values: openai, llamafile, and ollama
 #[allow(dead_code)]
 #[derive(PartialEq)]
+#[derive(Clone)]
 pub enum LlavaBackendType {
 
     // This works
@@ -78,6 +81,7 @@ impl FromStr for LlavaBackendType {
 }
 
 #[derive(PartialEq)]
+#[derive(Clone)]
 enum FocusGuardState {
     Idle,
     Primed,
@@ -93,6 +97,7 @@ impl fmt::Display for FocusGuardState {
     
 }
 
+#[derive(Clone)]
 pub struct FocusGuard {
     pub job_title: String,
     pub job_role: String,
@@ -119,6 +124,9 @@ pub struct FocusGuard {
     // the Llamafile binary
     app_data_dir: PathBuf,
 
+    // The path to the screentap database, where focusguard will store its own tables
+    screentap_db_path: PathBuf,
+
     // Amorphous dev mode flag to speed up dev
     dev_mode: bool,
 
@@ -129,11 +137,34 @@ pub struct FocusGuard {
 
 impl FocusGuard {
 
-    pub fn tauri_handler(&mut self, app: &tauri::AppHandle, event: String, payload: String) {
-        println!("FocusGuard received event: {} with payload: {}", event, payload);
+    fn get_db_conn(screentap_db_path: &PathBuf) -> rusqlite::Connection {
+        rusqlite::Connection::open(screentap_db_path).unwrap()
     }
 
-    pub fn new_from_config(app_data_dir: PathBuf) -> Option<FocusGuard> {
+    fn create_table_if_doesnt_exist(screentap_db_path: &PathBuf) -> Result<()> {
+
+        // Create the focusguard database table if it doesn't exist
+        let conn = FocusGuard::get_db_conn(screentap_db_path);
+
+        // Create a table with the desired columns
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS focusguard_distraction_alerts (
+                    id INTEGER PRIMARY KEY,
+                    screenshot_id INTEGER,
+                    user_rating INTEGER,
+                    timestamp TIMESTAMP NOT NULL,
+                    file_path TEXT NOT NULL,
+                    job_title TEXT NOT NULL,
+                    job_role TEXT NOT NULL
+                )",
+            [],
+        )?;
+
+        Ok(())
+    
+    }
+
+    pub fn new_from_config(app_data_dir: PathBuf, screentap_db_path: PathBuf) -> Option<FocusGuard> {
 
         // Register plugin - create a new focusguard struct
         let focus_guard_config = config::FocusGuardConfig::new(app_data_dir.as_path());
@@ -158,6 +189,8 @@ impl FocusGuard {
         
                 // Initialize tracking vars so that it begins with an initial check
                 let last_distraction_alert_time = Instant::now() - duration_between_alerts - Duration::from_secs(1);
+
+                FocusGuard::create_table_if_doesnt_exist(&screentap_db_path).expect("Error creating focusguard tables");
         
                 FocusGuard {
                     job_title: config.job_title,
@@ -169,6 +202,7 @@ impl FocusGuard {
                     productivity_score_threshold: config.productivity_score_threshold,
                     image_dimension_longest_side: config.image_dimension_longest_side,
                     app_data_dir,
+                    screentap_db_path,
                     dev_mode: config.dev_mode,
                     state: FocusGuardState::Idle,
                 }

--- a/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
@@ -390,6 +390,7 @@ impl FocusGuard {
                     "raw_llm_result_base64": raw_llm_result_base64,
                     "png_image_path": png_image_path.to_str().unwrap(),
                     "job_title": self.job_title,
+                    "job_role": self.job_role,
                     
                 });
 
@@ -405,7 +406,14 @@ impl FocusGuard {
                 // Use an init script approach when creating a new window, since sending an event
                 // did not work in my testing.  Maybe it's not ready for events yet as some sort
                 // of race condition?
-                let init_script = get_init_script(screenshot_id, productivity_score, raw_llm_result, png_image_path.to_str().unwrap());
+                let init_script = get_init_script(
+                    screenshot_id, 
+                    productivity_score, 
+                    raw_llm_result, 
+                    png_image_path.to_str().unwrap(),
+                    &self.job_title,
+                    &self.job_role
+                );
 
                 // Create and show new window
                 let _w = tauri::WindowBuilder::new(
@@ -739,16 +747,24 @@ impl FocusGuard {
 }
 
 
-fn get_init_script(screenshot_id: i64, productivity_score: i32, raw_llm_result: &str, png_image_path: &str) -> String {
+fn get_init_script(screenshot_id: i64, productivity_score: i32, raw_llm_result: &str, png_image_path: &str, job_title: &str, job_role: &str) -> String {
 
     let raw_llm_result_base64: String = BASE64.encode(raw_llm_result);
     
     let png_image_path_base_64: String = BASE64.encode(png_image_path);
 
-    format!(r#"    
-        window.__SCREENTAP_SCREENSHOT__ = {{ id: '{}', productivity_score: {}, raw_llm_result_base64: '{}', png_image_path_base_64: '{}' }};
+    let job_title_base_64: String = BASE64.encode(job_title);
 
-    "#, screenshot_id, productivity_score, raw_llm_result_base64, png_image_path_base_64)
+    let job_role_base_64: String = BASE64.encode(job_role);
+
+    format!(r#"    
+        window.__SCREENTAP_SCREENSHOT__ = {{ id: '{}', productivity_score: {}, raw_llm_result_base64: '{}', png_image_path_base_64: '{}', job_title_base_64: '{}', job_role_base_64: '{}' }};
+    "#, screenshot_id, 
+        productivity_score, 
+        raw_llm_result_base64, 
+        png_image_path_base_64, 
+        job_title_base_64, 
+        job_role_base_64)
 }
 
 // Structs for payload

--- a/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
@@ -137,7 +137,7 @@ pub struct FocusGuard {
 
 impl FocusGuard {
 
-    fn get_db_conn(screentap_db_path: &PathBuf) -> rusqlite::Connection {
+    pub fn get_db_conn(screentap_db_path: &PathBuf) -> rusqlite::Connection {
         rusqlite::Connection::open(screentap_db_path).unwrap()
     }
 

--- a/screentap-app/src/components/Focusguard.vue
+++ b/screentap-app/src/components/Focusguard.vue
@@ -24,6 +24,8 @@ interface ScreenshotEventPayload {
   productivity_score: number;
   raw_llm_result_base64: string;
   png_image_path: string;
+  job_title: string;
+  job_role: string;
 }
 
 interface ScreenshotEvent {
@@ -54,8 +56,12 @@ const isVisibleExplanationLLMInferResult = ref(false);
 
 const productivityScore = ref(0);
 
+const jobTitle = ref('');
+
+const jobRole = ref('');
+
 async function recordDistractionAlertFeedback(liked: boolean) {
-  await invoke("distraction_alert_rating", { liked: liked, screenshotId: screenshotId.value, pngImagePath: pngImagePath.value });
+  await invoke("distraction_alert_rating", { liked: liked, screenshotId: screenshotId.value, pngImagePath: pngImagePath.value, jobTitle: jobTitle.value, jobRole: jobRole.value});
   console.log('screenshot id', screenshotId.value);
   closeWindow();
 }
@@ -87,6 +93,18 @@ async function getScreenshot() {
         console.error('window.__SCREENTAP_SCREENSHOT__.png_image_path_base_64 is not defined');
     }
 
+    if (window.__SCREENTAP_SCREENSHOT__ && window.__SCREENTAP_SCREENSHOT__.hasOwnProperty('job_title_base_64')) {
+        jobTitle.value = atob(window.__SCREENTAP_SCREENSHOT__.job_title_base_64);
+    } else {
+        console.error('window.__SCREENTAP_SCREENSHOT__.job_title_base_64 is not defined');
+    }
+
+    if (window.__SCREENTAP_SCREENSHOT__ && window.__SCREENTAP_SCREENSHOT__.hasOwnProperty('job_role_base_64')) {
+        jobRole.value = atob(window.__SCREENTAP_SCREENSHOT__.job_role_base_64);
+    } else {
+        console.error('window.__SCREENTAP_SCREENSHOT__.job_role_base_64 is not defined');
+    }
+
 
 }
 
@@ -114,6 +132,8 @@ listen('update-screenshot-event', (event: ScreenshotEvent) => {
   explanationLLMInferResult.value = atob(event.payload.raw_llm_result_base64);
   getScreenshotById(event.payload.screenshot_id);
   pngImagePath.value = event.payload.png_image_path;
+  jobTitle.value = event.payload.job_title;
+  jobRole.value = event.payload.job_role;
 });
 
 getScreenshot()

--- a/screentap-app/src/components/Focusguard.vue
+++ b/screentap-app/src/components/Focusguard.vue
@@ -51,6 +51,12 @@ const isVisibleExplanationLLMInferResult = ref(false);
 
 const productivityScore = ref(0);
 
+async function recordDistractionAlertFeedback(liked: boolean) {
+  await invoke("distraction_alert_rating", { liked: liked, screenshotId: screenshotId.value });
+  console.log('screenshot id', screenshotId.value);
+  closeWindow();
+}
+
 
 async function getScreenshot() {
     // The __SCREENTAP_SCREENSHOT__ window property is set by the rust backend before showing the window
@@ -119,8 +125,8 @@ getScreenshot()
         </p>
 
         <div class="flex space-x-2 mb-8">
-            <button class="btn btn-primary" @click="closeWindow">👍 Yes</button>
-            <button class="btn btn-secondary" @click="closeWindow">👎 No</button>
+            <button class="btn btn-primary" @click="recordDistractionAlertFeedback(true)">👍 Yes</button>
+            <button class="btn btn-secondary" @click="recordDistractionAlertFeedback(false)">👎 No</button>
         </div>
 
         <fwb-accordion class="mt-4 mx-4 mb-4" :open-first-item="false">

--- a/screentap-app/src/components/Focusguard.vue
+++ b/screentap-app/src/components/Focusguard.vue
@@ -23,6 +23,7 @@ interface ScreenshotEventPayload {
   screenshot_id: number;
   productivity_score: number;
   raw_llm_result_base64: string;
+  png_image_path: string;
 }
 
 interface ScreenshotEvent {
@@ -47,12 +48,14 @@ const getScreenshotResult = ref([]);
 // Explanation of LLM infer result
 const explanationLLMInferResult = ref('');
 
+const pngImagePath = ref('');
+
 const isVisibleExplanationLLMInferResult = ref(false);
 
 const productivityScore = ref(0);
 
 async function recordDistractionAlertFeedback(liked: boolean) {
-  await invoke("distraction_alert_rating", { liked: liked, screenshotId: screenshotId.value });
+  await invoke("distraction_alert_rating", { liked: liked, screenshotId: screenshotId.value, pngImagePath: pngImagePath.value });
   console.log('screenshot id', screenshotId.value);
   closeWindow();
 }
@@ -77,6 +80,13 @@ async function getScreenshot() {
     } else {
         console.error('window.__SCREENTAP_SCREENSHOT__.raw_llm_result_base64 is not defined');
     }
+
+    if (window.__SCREENTAP_SCREENSHOT__ && window.__SCREENTAP_SCREENSHOT__.hasOwnProperty('png_image_path_base_64')) {
+        pngImagePath.value = atob(window.__SCREENTAP_SCREENSHOT__.png_image_path_base_64);
+    } else {
+        console.error('window.__SCREENTAP_SCREENSHOT__.png_image_path_base_64 is not defined');
+    }
+
 
 }
 
@@ -103,8 +113,7 @@ listen('update-screenshot-event', (event: ScreenshotEvent) => {
   productivityScore.value = event.payload.productivity_score;
   explanationLLMInferResult.value = atob(event.payload.raw_llm_result_base64);
   getScreenshotById(event.payload.screenshot_id);
-
-
+  pngImagePath.value = event.payload.png_image_path;
 });
 
 getScreenshot()


### PR DESCRIPTION
* Store the result in a new sqlite table
* Copy the screenshot image to another directory managed by focusguard

The feedback isn't acted on yet, hopefully that will come later