### PR TITLE
Faster image resize

### DIFF
--- a/screen-ocr-swift-rs/src/lib.rs
+++ b/screen-ocr-swift-rs/src/lib.rs
@@ -20,10 +20,10 @@ pub fn extract_frame_from_mp4(mp4_path: &str, frame_id: isize) -> Option<SRData>
 }
 
 
-pub fn resize_image(png_data: Vec<u8>, scale: f32) -> Vec<u8> {
+pub fn resize_image(png_data: &[u8], scale: f32) -> Vec<u8> {
 
-    // Convert the vector to a SRData
-    let image = SRData::from(&*png_data);
+      // Convert the vector to a SRData
+    let image = SRData::from(png_data);
 
     let result = unsafe { resize_image_swift(image, scale) };
     

--- a/screen-ocr-swift-rs/src/lib.rs
+++ b/screen-ocr-swift-rs/src/lib.rs
@@ -20,14 +20,18 @@ pub fn extract_frame_from_mp4(mp4_path: &str, frame_id: isize) -> Option<SRData>
 }
 
 
-pub fn resize_image(png_data: &[u8], scale: f32) -> Vec<u8> {
+pub fn resize_image(png_data: &[u8], scale: f32) -> Option<Vec<u8>> {
 
-      // Convert the vector to a SRData
+    // Convert the vector to a SRData
     let image = SRData::from(png_data);
 
-    let result = unsafe { resize_image_swift(image, scale) };
-    
-    result.unwrap().to_vec()
+    // Call the swift function
+    let resized_img_opt = unsafe { 
+        resize_image_swift(image, scale) 
+    };
+
+    // Convert the result from SRData to Vec<u8>
+    resized_img_opt.map(|data| data.to_vec()) 
 
 }
 

--- a/screen-ocr-swift-rs/src/lib.rs
+++ b/screen-ocr-swift-rs/src/lib.rs
@@ -22,12 +22,6 @@ pub fn extract_frame_from_mp4(mp4_path: &str, frame_id: isize) -> Option<SRData>
 
 pub fn resize_image(png_data: Vec<u8>) -> Vec<u8> {
 
-    // let str: &str = "hello";
-    // let bytes: Vec<u8> = str.as_bytes().to_vec();
-
-    // let swift_byte: SRData = SRData::from(&bytes);
-    // let swift_byte: SRData = SRData::from(&*bytes);
-
     // Convert the vector to a SRData
     let image = SRData::from(&*png_data);
 

--- a/screen-ocr-swift-rs/src/lib.rs
+++ b/screen-ocr-swift-rs/src/lib.rs
@@ -1,4 +1,4 @@
-use swift_rs::{swift, SRString, SRData, Int, Bool};
+use swift_rs::{swift, SRString, SRData, Int, Bool, Float};
 
 use std::fs::File;
 use std::io::prelude::*;
@@ -9,7 +9,7 @@ swift!(fn screen_capture_swift() -> Option<SRData>);
 swift!(fn write_images_in_dir_to_mp4_swift(directory_path: &SRString, target_filename: &SRString, use_bitrate_key: Bool) -> ());
 swift!(fn extract_frame_from_mp4_swift(mp4_path: &SRString, frame_id: Int) -> Option<SRData>);    
 swift!(fn get_frontmost_app_swift() -> SRString);
-swift!(fn resize_image_swift(image: SRData) ->  Option<SRData>);
+swift!(fn resize_image_swift(image: SRData, scale: Float) ->  Option<SRData>);
 
 
 pub fn extract_frame_from_mp4(mp4_path: &str, frame_id: isize) -> Option<SRData> {
@@ -20,12 +20,12 @@ pub fn extract_frame_from_mp4(mp4_path: &str, frame_id: isize) -> Option<SRData>
 }
 
 
-pub fn resize_image(png_data: Vec<u8>) -> Vec<u8> {
+pub fn resize_image(png_data: Vec<u8>, scale: f32) -> Vec<u8> {
 
     // Convert the vector to a SRData
     let image = SRData::from(&*png_data);
 
-    let result = unsafe { resize_image_swift(image) };
+    let result = unsafe { resize_image_swift(image, scale) };
     
     result.unwrap().to_vec()
 

--- a/screen-ocr-swift-rs/src/lib.rs
+++ b/screen-ocr-swift-rs/src/lib.rs
@@ -9,6 +9,7 @@ swift!(fn screen_capture_swift() -> Option<SRData>);
 swift!(fn write_images_in_dir_to_mp4_swift(directory_path: &SRString, target_filename: &SRString, use_bitrate_key: Bool) -> ());
 swift!(fn extract_frame_from_mp4_swift(mp4_path: &SRString, frame_id: Int) -> Option<SRData>);    
 swift!(fn get_frontmost_app_swift() -> SRString);
+swift!(fn resize_image_swift(image: SRData) ->  Option<SRData>);
 
 
 pub fn extract_frame_from_mp4(mp4_path: &str, frame_id: isize) -> Option<SRData> {
@@ -19,6 +20,22 @@ pub fn extract_frame_from_mp4(mp4_path: &str, frame_id: isize) -> Option<SRData>
 }
 
 
+pub fn resize_image(png_data: Vec<u8>) -> Vec<u8> {
+
+    // let str: &str = "hello";
+    // let bytes: Vec<u8> = str.as_bytes().to_vec();
+
+    // let swift_byte: SRData = SRData::from(&bytes);
+    // let swift_byte: SRData = SRData::from(&*bytes);
+
+    // Convert the vector to a SRData
+    let image = SRData::from(&*png_data);
+
+    let result = unsafe { resize_image_swift(image) };
+    
+    result.unwrap().to_vec()
+
+}
 
 /**
  * Given a path to a directory of images, write them to an mp4

--- a/screen-ocr-swift-rs/vision-swift/Sources/vision-swift/vision_swift.swift
+++ b/screen-ocr-swift-rs/vision-swift/Sources/vision-swift/vision_swift.swift
@@ -81,7 +81,7 @@ public func get_frontmost_app() -> SRString {
 
 @_cdecl("resize_image_swift")
 @available(macOS 10.15, *)
-public func resize_image(image: SRData) -> SRData? {
+public func resize_image(image: SRData, scale: Float) -> SRData? {
 
     // Convert the byte array to CGImage
     let byteArray = image.toArray()
@@ -89,7 +89,7 @@ public func resize_image(image: SRData) -> SRData? {
     if let cgImage = byteArrayToCGImage(byteArray: byteArray) {
 
         // Resize the image
-        if let resizedCGImage = resizedImage(image: cgImage, scale: 0.5) {
+        if let resizedCGImage = resizedImage(image: cgImage, scale: CGFloat(scale)) {
 
             // Convert the resized CGImage to byte array
             if let resizedByteArray = convertCGImageToByteArray(image: resizedCGImage) {

--- a/screen-ocr-swift-rs/vision-swift/Sources/vision-swift/vision_swift.swift
+++ b/screen-ocr-swift-rs/vision-swift/Sources/vision-swift/vision_swift.swift
@@ -89,7 +89,7 @@ public func resize_image(image: SRData, scale: Float) -> SRData? {
     if let cgImage = byteArrayToCGImage(byteArray: byteArray) {
 
         // Resize the image
-        if let resizedCGImage = resizedImage(image: cgImage, scale: CGFloat(scale)) {
+        if let resizedCGImage = resizeImage(image: cgImage, scale: CGFloat(scale)) {
 
             // Convert the resized CGImage to byte array
             if let resizedByteArray = convertCGImageToByteArray(image: resizedCGImage) {
@@ -515,7 +515,7 @@ func convertCGImageToByteArray(image: CGImage) -> [UInt8]? {
     return byteArray
 }
 
-func resizedImage(image: CGImage, scale: CGFloat) -> CGImage? {
+func resizeImage(image: CGImage, scale: CGFloat) -> CGImage? {
     
     let sharedContext = CIContext(options: [.useSoftwareRenderer : false])
     

--- a/screen-ocr-swift-rs/vision-swift/Sources/vision-swift/vision_swift.swift
+++ b/screen-ocr-swift-rs/vision-swift/Sources/vision-swift/vision_swift.swift
@@ -79,13 +79,42 @@ public func get_frontmost_app() -> SRString {
     }
 }
 
+@_cdecl("resize_image_swift")
+@available(macOS 10.15, *)
+public func resize_image(image: SRData) -> SRData? {
+
+    // Convert the byte array to CGImage
+    let byteArray = image.toArray()
+
+    if let cgImage = byteArrayToCGImage(byteArray: byteArray) {
+
+        // Resize the image
+        if let resizedCGImage = resizedImage(image: cgImage, scale: 0.5) {
+
+            // Convert the resized CGImage to byte array
+            if let resizedByteArray = convertCGImageToByteArray(image: resizedCGImage) {
+                return SRData(resizedByteArray)
+            } else {
+                print("Failed to convert resized CGImage to byte array")
+            }
+
+        } else {
+            print("Failed to resize image")
+        }
+
+    } else {
+        print("Failed to convert byte array to CGImage")
+    }
+
+    return nil
+}
+
 /**
  * Capture the screen and return the image as a PNG encoded byte array
  */
 @_cdecl("screen_capture_swift")
 @available(macOS 10.15, *)
 public func screen_capture() -> SRData? {
-
 
     // Specify the display to capture (main display in this case)
     let displayID = CGMainDisplayID()
@@ -484,4 +513,25 @@ func convertCGImageToByteArray(image: CGImage) -> [UInt8]? {
     // Convert NSData to Byte Array
     let byteArray = [UInt8](imageData)
     return byteArray
+}
+
+func resizedImage(image: CGImage, scale: CGFloat) -> CGImage? {
+    
+    let sharedContext = CIContext(options: [.useSoftwareRenderer : false])
+    
+    // Convert CGImage to CIImage
+    let ciImage = CIImage(cgImage: image)
+    
+    let filter = CIFilter(name: "CILanczosScaleTransform")
+    filter?.setValue(ciImage, forKey: kCIInputImageKey)
+    filter?.setValue(scale, forKey: kCIInputScaleKey)
+
+    guard let outputCIImage = filter?.outputImage,
+        let outputCGImage = sharedContext.createCGImage(outputCIImage,
+                                                        from: outputCIImage.extent)
+    else {
+        return nil
+    }
+
+    return outputCGImage
 }

--- a/screentap-app/plugins/focusguard/config_sample.toml
+++ b/screentap-app/plugins/focusguard/config_sample.toml
@@ -30,10 +30,11 @@ openai_api_key = ""
 # The threshold for the productivity score before it considers it a distraction
 productivity_score_threshold = 6
 
-# When resizing images, resize the longest size to this pixel value.
-# Set this to a lower value to reduce the OpenAI token costs, at the
-# expense of results quality.
-image_dimension_longest_side = 1600
+# How much to scale down the raw screenshot before sending to the vision model.
+# This must be a number between 0.1 and 1.0.  
+# Setting this to a smaller value will consume less tokens on the vision model,
+# at the cost of quality.
+image_resize_scale = 0.65
 
 # Ignore this param, just internal stuff
 dev_mode = false

--- a/screentap-app/src-tauri/src/main.rs
+++ b/screentap-app/src-tauri/src/main.rs
@@ -210,15 +210,6 @@ fn setup_handler(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error +
             match screenshot_result {
                 Ok(screenshot::ScreenshotSaveResult { png_data, ocr_text, png_image_path, screenshot_id}) => {
 
-                    println!("Resizing screenshot with swift...");
-                    let resized_img = screen_ocr_swift_rs::resize_image(png_data.clone());
-
-                    // Write resized image to disk
-                    let path = Path::new("/tmp/resized_rust.png");
-                    std::fs::write(path, &resized_img).unwrap();
-                    println!("Wrote resized image to disk: /tmp/resized_rust.png");
-
-
                     // Invoke plugins
                     // TODO: any way to avoid this confusing "ref mut" stuff?
                     if let Some(ref mut focus_guard) = focus_guard_option {

--- a/screentap-app/src-tauri/src/main.rs
+++ b/screentap-app/src-tauri/src/main.rs
@@ -209,6 +209,16 @@ fn setup_handler(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error +
             let screenshot_result = screenshot::save_screenshot(app_data_dir.as_path(), db_filename_path);
             match screenshot_result {
                 Ok(screenshot::ScreenshotSaveResult { png_data, ocr_text, png_image_path, screenshot_id}) => {
+
+                    println!("Resizing screenshot with swift...");
+                    let resized_img = screen_ocr_swift_rs::resize_image(png_data.clone());
+
+                    // Write resized image to disk
+                    let path = Path::new("/tmp/resized_rust.png");
+                    std::fs::write(path, &resized_img).unwrap();
+                    println!("Wrote resized image to disk: /tmp/resized_rust.png");
+
+
                     // Invoke plugins
                     // TODO: any way to avoid this confusing "ref mut" stuff?
                     if let Some(ref mut focus_guard) = focus_guard_option {

--- a/screentap-app/src-tauri/src/plugins/focusguard/config.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/config.rs
@@ -12,7 +12,7 @@ pub struct FocusGuardConfig {
     pub llava_backend: String,
     pub openai_api_key: String,
     pub productivity_score_threshold: i32,
-    pub image_dimension_longest_side: u32,
+    pub image_resize_scale: f32,
     pub dev_mode: bool,
 }
 

--- a/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
@@ -306,8 +306,7 @@ impl FocusGuard {
                 now = Instant::now();
 
                 // Resize the image before sending to the vision model
-                // TODO: just capture image in target dimensions in the first place, this will save a lot of resources.
-                // TODO: or if that's not possible, move the resizing to native swift libraries to take adcantage of apple silicon
+                // TODO: figure out how to pass a reference of png_data to avoid moving it (in case we need it later)
                 let resize_img_result = FocusGuard::resize_image(
                     png_data, 
                     self.image_resize_scale
@@ -365,10 +364,10 @@ impl FocusGuard {
 
     }
 
-
+    /**
+     * Resize the image using the native Swift code
+     */
     fn resize_image(png_data: Vec<u8>, scale: f32) -> Result<Vec<u8>, image::ImageError> {
-
-        println!("Resizing screenshot with swift...");
 
         let resized_img = screen_ocr_swift_rs::resize_image(png_data, scale);  // TODO: remove this clone, pass a reference
 

--- a/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
@@ -313,9 +313,9 @@ impl FocusGuard {
 
                 // Get the resized png data
                 let resized_png_data = match resize_img_result {
-                    Ok(resized_img) => resized_img,
-                    Err(e) => {
-                        println!("Error resizing image: {}", e);
+                    Some(resized_img) => resized_img,
+                    None => {
+                        println!("Error resizing image: see logs.  FocusGuard will not analyze this screenshot.");
                         return
                     }
                 };
@@ -366,11 +366,9 @@ impl FocusGuard {
     /**
      * Resize the image using the native Swift code
      */
-    fn resize_image(png_data: &[u8], scale: f32) -> Result<Vec<u8>, image::ImageError> {
+    fn resize_image(png_data: &[u8], scale: f32) -> Option<Vec<u8>> {
 
-        let resized_img = screen_ocr_swift_rs::resize_image(png_data, scale);
-
-        Ok(resized_img)
+        screen_ocr_swift_rs::resize_image(png_data, scale)
 
     }
 

--- a/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
@@ -306,9 +306,8 @@ impl FocusGuard {
                 now = Instant::now();
 
                 // Resize the image before sending to the vision model
-                // TODO: figure out how to pass a reference of png_data to avoid moving it (in case we need it later)
                 let resize_img_result = FocusGuard::resize_image(
-                    png_data, 
+                    &png_data, 
                     self.image_resize_scale
                 );
 
@@ -367,9 +366,9 @@ impl FocusGuard {
     /**
      * Resize the image using the native Swift code
      */
-    fn resize_image(png_data: Vec<u8>, scale: f32) -> Result<Vec<u8>, image::ImageError> {
+    fn resize_image(png_data: &[u8], scale: f32) -> Result<Vec<u8>, image::ImageError> {
 
-        let resized_img = screen_ocr_swift_rs::resize_image(png_data, scale);  // TODO: remove this clone, pass a reference
+        let resized_img = screen_ocr_swift_rs::resize_image(png_data, scale);
 
         Ok(resized_img)
 

--- a/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
@@ -1,3 +1,4 @@
+extern crate screen_ocr_swift_rs;
 
 use std::time::{Instant, Duration};
 use serde::Serialize;
@@ -370,32 +371,13 @@ impl FocusGuard {
 
     fn resize_image(png_data: Vec<u8>, max_dimension: u32) -> Result<Vec<u8>, image::ImageError> {
 
-        // Load the image from a byte slice (&[u8])
-        let img = image::load_from_memory(&png_data)?;
-    
-        // Calculate the new dimensions
-        let (width, height) = img.dimensions();
-        let aspect_ratio = width as f32 / height as f32;
-        let (new_width, new_height) = if width > height {
-            let new_width = max_dimension;
-            let new_height = (max_dimension as f32 / aspect_ratio).round() as u32;
-            (new_width, new_height)
-        } else {
-            let new_height = max_dimension;
-            let new_width = (max_dimension as f32 * aspect_ratio).round() as u32;
-            (new_width, new_height)
-        };
-    
-        // Resize the image
-        let resized = img.resize_exact(
-            new_width, 
-            new_height, 
-            FilterType::Lanczos3
-        );
-    
-        let mut bytes = Cursor::new(Vec::new());
-        resized.write_to(&mut bytes, image::ImageOutputFormat::Png)?;
-        Ok(bytes.into_inner())
+        println!("Resizing screenshot with swift...");
+
+        // TODO: respect the max dimension, or maybe just take in a scale ratio and pass that into the swift code
+
+        let resized_img = screen_ocr_swift_rs::resize_image(png_data.clone());  // TODO: remove this clone, pass a reference
+
+        Ok(resized_img)
 
     }
 


### PR DESCRIPTION
Fixes #47 by moving the implementation from rust -> swift.  The rust implementation might not have been optimal, and hopefully the swift implementation is taking advantage of some hardware acceleration.

Image resize times have gone down from 10-45s -> ~300ms