### PR TITLE
Add perceptual hashing

### DIFF
--- a/screentap-app/src-tauri/Cargo.lock
+++ b/screentap-app/src-tauri/Cargo.lock
@@ -1033,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
+checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
 dependencies = [
  "color_quant",
  "weezl",
@@ -1445,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034bbe799d1909622a74d1193aa50147769440040ff36cb2baa947609b0a4e23"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -1459,6 +1459,19 @@ dependencies = [
  "png",
  "qoi",
  "tiff",
+]
+
+[[package]]
+name = "image_hasher"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9e64a8c472ea9f81ac448e3b488fd82dcdfce6434cf880882bf36bfb5c268a"
+dependencies = [
+ "base64 0.21.6",
+ "image",
+ "rustdct",
+ "serde",
+ "transpose",
 ]
 
 [[package]]
@@ -1879,6 +1892,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2290,6 +2321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "primal-check"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df7f93fd637f083201473dab4fee2db4c429d32e55e3299980ab3957ab916a0"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2607,6 +2647,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b61555105d6a9bf98797c063c362a1d24ed8ab0431655e38f1cf51e52089551"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43806561bc506d0c5d160643ad742e3161049ac01027b5e6d7524091fd401d86"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+ "version_check",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2691,6 +2755,7 @@ dependencies = [
  "base64 0.21.6",
  "chrono",
  "image",
+ "image_hasher",
  "ollama-rs",
  "rand 0.8.5",
  "regex",
@@ -2991,6 +3056,12 @@ checksum = "dbe866e1e51e8260c9eed836a042a5e7f6726bb2b411dffeaa712e19c388f23b"
 dependencies = [
  "loom",
 ]
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
@@ -3662,6 +3733,16 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]

--- a/screentap-app/src-tauri/Cargo.toml
+++ b/screentap-app/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ screen-ocr-swift-rs = { path = "../../screen-ocr-swift-rs"}
 chrono = "0.4.31"
 rusqlite = { version = "0.30.0", features = ["chrono"] }
 base64 = "0.21.6"
-image = "0.24.8"
+image = "0.24.9"
 rand = "0.8.5"
 tempfile = "3.9.0"
 backtrace = "0.3.69"
@@ -30,6 +30,7 @@ regex = "1.10.3"
 url = "2.5.0"
 ollama-rs = "0.1.7"
 tokio = "1.36.0"
+image_hasher = "1.2.0"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/screentap-app/src-tauri/src/compaction.rs
+++ b/screentap-app/src-tauri/src/compaction.rs
@@ -6,7 +6,10 @@ use rusqlite::params;
 
 
 // The maximum number of image files allowed to accumulate before compacting to an MP4
-pub const DEFAULT_MAX_IMAGE_FILES: u32 = 150;
+// 
+// TODO: make this configurable via toml file.  
+//       I need to make it larger for dev purposes, but it should be more like 100
+pub const DEFAULT_MAX_IMAGE_FILES: u32 = 500;
 
 
 /**

--- a/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
@@ -139,7 +139,7 @@ pub struct FocusGuard {
 
 impl FocusGuard {
 
-    fn calculate_perceptual_hash(png_data: &Vec<u8>) -> ImageHash {
+    fn calculate_perceptual_hash(png_data: &[u8]) -> ImageHash {
 
         // Get the current time
         let now = Instant::now();
@@ -345,7 +345,7 @@ impl FocusGuard {
 
         // Is the perceptual hash delta above the threshold?  If not, short circuit the call to the vision model
         // for massive cost savings in tokens and/or compute budget. 
-        let above_threshold = self.phash_delta_above_threshold(&resized_png_data, &png_image_path);
+        let above_threshold = self.phash_delta_above_threshold(&resized_png_data, png_image_path);
         if !above_threshold {
             return
         }
@@ -403,14 +403,14 @@ impl FocusGuard {
 
     }
 
-    pub fn phash_delta_above_threshold(&mut self, png_data: &Vec<u8>, png_image_path: &Path) -> bool {
+    pub fn phash_delta_above_threshold(&mut self, png_data: &[u8], png_image_path: &Path) -> bool {
 
         println!("Calculating perceptual hash of image {} ...", png_image_path.display());
-        let phash: ImageHash = FocusGuard::calculate_perceptual_hash(&png_data);
+        let phash: ImageHash = FocusGuard::calculate_perceptual_hash(png_data);
 
         let result = match &self.previous_phash_opt {
             Some(previous_phash) => {
-                let dist: u32 = phash.dist(&previous_phash);
+                let dist: u32 = phash.dist(previous_phash);
                 let phash_threshold = 200;  // TODO: move to config.toml
                 if dist < phash_threshold {  // TODO: tune this threshold
                     println!("phash delta is {}, which is below {} and not enough to warrant a new analysis", dist, phash_threshold);

--- a/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
@@ -140,10 +140,21 @@ pub struct FocusGuard {
 impl FocusGuard {
 
     fn calculate_perceptual_hash(png_data: &Vec<u8>) -> ImageHash {
+
+        // Get the current time
+        let now = Instant::now();
+
         let hasher_config = HasherConfig::new().hash_size(32, 32).preproc_dct();
         let hasher = hasher_config.to_hasher();
         let img = image::load_from_memory(png_data).unwrap();
-        hasher.hash_image(&img)
+        let hashed_img = hasher.hash_image(&img);
+
+        // calculate the time it took to hash the image
+        let time_to_hash = now.elapsed();
+        println!("Time to calculate perceptual hash: {:?}", time_to_hash);
+
+        hashed_img
+
     }
 
     pub fn get_db_conn(screentap_db_path: &PathBuf) -> rusqlite::Connection {

--- a/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
+++ b/screentap-app/src-tauri/src/plugins/focusguard/mod.rs
@@ -21,6 +21,7 @@ use ollama_rs::{
 };
 use tokio::runtime;
 use rusqlite::Result;
+use image_hasher::{HasherConfig, ImageHash};
 
 
 mod utils;
@@ -131,9 +132,19 @@ pub struct FocusGuard {
     // The state used to determine when to invoke the vision model
     state: FocusGuardState,
 
+    // The previous perceptual hash of the image
+    previous_phash_opt: Option<ImageHash>,
+
 }
 
 impl FocusGuard {
+
+    fn calculate_perceptual_hash(png_data: &Vec<u8>) -> ImageHash {
+        let hasher_config = HasherConfig::new().hash_size(32, 32).preproc_dct();
+        let hasher = hasher_config.to_hasher();
+        let img = image::load_from_memory(png_data).unwrap();
+        hasher.hash_image(&img)
+    }
 
     pub fn get_db_conn(screentap_db_path: &PathBuf) -> rusqlite::Connection {
         rusqlite::Connection::open(screentap_db_path).unwrap()
@@ -203,6 +214,7 @@ impl FocusGuard {
                     screentap_db_path,
                     dev_mode: config.dev_mode,
                     state: FocusGuardState::Idle,
+                    previous_phash_opt: None,
                 }
 
             },
@@ -241,7 +253,7 @@ impl FocusGuard {
                 if !frontmost_app_or_tab_changed {
                     // The system is primed and the user is lingering in the same app or browser tab, 
                     // therefore we should invoke the vision model and reset the state to IDLE
-                    println!("FocusGuard invoking vision model and resetting state to IDLE");
+                    println!("FocusGuard invoking vision model ...");
                     self.state = FocusGuardState::Idle;
                     true
                 } else {
@@ -292,18 +304,15 @@ impl FocusGuard {
             return;
         }
 
-        let prompt = self.create_prompt();
-
-        let (productivity_score, raw_llm_result) = match self.dev_mode {
-            true => {
-                println!("FocusGuard returning hardcoded productivity score");
-                (2, "".to_string())
-            },  
-            false => {
-                // Invoke the actual vision model
-                println!("FocusGuard analyzing image with {}.  Resizing image at png_image_path: {}", self.llava_backend, png_image_path.display());
-
-                now = Instant::now();
+        // If dev mode is enabled, don't invoke the vision model and short-circuit the processing
+        if self.dev_mode {
+            println!("FocusGuard: dev mode is enabled, not invoking vision model");
+            println!("FocusGuard returning hardcoded productivity score");
+            return;
+        }
+        
+        println!("FocusGuard: resizing image (can be slow) ..");
+        now = Instant::now();
 
                 // Resize the image before sending to the vision model
                 let resize_img_result = FocusGuard::resize_image(
@@ -320,36 +329,47 @@ impl FocusGuard {
                     }
                 };
 
-                let time_to_resize = now.elapsed();
-                println!("Resized image by {} to {} bytes: time_to_resize: {:?}", self.image_resize_scale, resized_png_data.len(), time_to_resize);
+        let time_to_resize = now.elapsed();
+        println!("Resized image by {} to {} bytes: time_to_resize: {:?}", self.image_resize_scale, resized_png_data.len(), time_to_resize);
 
-                now = Instant::now();
+        // Is the perceptual hash delta above the threshold?  If not, short circuit the call to the vision model
+        // for massive cost savings in tokens and/or compute budget. 
+        let above_threshold = self.phash_delta_above_threshold(&resized_png_data, &png_image_path);
+        if !above_threshold {
+            return
+        }
 
-                let raw_result = match self.llava_backend {
-                    LlavaBackendType::OpenAI => self.invoke_openai_vision_model(&prompt, &resized_png_data),
-                    LlavaBackendType::Ollama => self.invoke_ollama_vision_model(&prompt, &resized_png_data),
-                    LlavaBackendType::LlamaFile => self.invoke_openai_vision_model(&prompt, &resized_png_data),
-                    LlavaBackendType::LlamaFileSubprocess => self.invoke_subprocess_vision_model(&prompt, png_image_path),
-                };
+        let prompt = self.create_prompt();
 
-                let time_to_infer = now.elapsed();
-                println!("time_to_infer: {:?}", time_to_infer);
+        let (productivity_score, raw_llm_result) = {
+            // Invoke the actual vision model
+            println!("FocusGuard analyzing image with {}.  Resizing image at png_image_path: {}", self.llava_backend, png_image_path.display());
 
-                match self.process_vision_model_result(&raw_result) { 
-                    Some(raw_result_i32) => {
-                        (raw_result_i32, raw_result)
-                    },
-                    None => {
-                        println!("FocusGuard could not parse raw result [{}] into number", raw_result);
-                        return
-                    }
+            now = Instant::now();
+
+            let raw_result = match self.llava_backend {
+                LlavaBackendType::OpenAI => self.invoke_openai_vision_model(&prompt, &resized_png_data),
+                LlavaBackendType::Ollama => self.invoke_ollama_vision_model(&prompt, &resized_png_data),
+                LlavaBackendType::LlamaFile => self.invoke_openai_vision_model(&prompt, &resized_png_data),
+                LlavaBackendType::LlamaFileSubprocess => self.invoke_subprocess_vision_model(&prompt, png_image_path),
+            };
+
+            let time_to_infer = now.elapsed();
+            println!("time_to_infer: {:?}", time_to_infer);
+
+            match self.process_vision_model_result(&raw_result) { 
+                Some(raw_result_i32) => {
+                    (raw_result_i32, raw_result)
+                },
+                None => {
+                    println!("FocusGuard could not parse raw result [{}] into number", raw_result);
+                    return
                 }
-
             }
+    
         };
 
         // Record the productivity score in the database as this can be used for metrics tracking
-
         if productivity_score < self.productivity_score_threshold {
             println!("Productivity score {} is below threshold {} for png_image_path: {}", productivity_score, self.productivity_score_threshold, png_image_path.display());
 
@@ -372,7 +392,33 @@ impl FocusGuard {
 
     }
 
+    pub fn phash_delta_above_threshold(&mut self, png_data: &Vec<u8>, png_image_path: &Path) -> bool {
 
+        println!("Calculating perceptual hash of image {} ...", png_image_path.display());
+        let phash: ImageHash = FocusGuard::calculate_perceptual_hash(&png_data);
+
+        let result = match &self.previous_phash_opt {
+            Some(previous_phash) => {
+                let dist: u32 = phash.dist(&previous_phash);
+                let phash_threshold = 200;  // TODO: move to config.toml
+                if dist < phash_threshold {  // TODO: tune this threshold
+                    println!("phash delta is {}, which is below {} and not enough to warrant a new analysis", dist, phash_threshold);
+                    false
+                } else {
+                    println!("phash delta is {}, which is above {} and enough to warrant a new analysis", dist, phash_threshold);
+                    true
+                }
+            },
+            None => {
+                println!("phash: {}, but no previous phash to compare to.  Assume delta not above threshold.", phash.to_base64());
+                false
+            }
+        };
+
+        self.previous_phash_opt = Some(phash);
+        
+        result
+    }
 
     fn show_productivity_alert(&self, app: &tauri::AppHandle, productivity_score: i32, raw_llm_result: &str, png_image_path: &Path, screenshot_id: i64) {
 


### PR DESCRIPTION
Reduce calls to the vision model by comparing the perceptual hash with the screenshot that was last sent to the vision model.  If less than a threshold because the screenshots are too similar, then skip the call to the vision model.